### PR TITLE
Remove unsupported options from BBCode tag

### DIFF
--- a/js/imageupload.js
+++ b/js/imageupload.js
@@ -36,7 +36,7 @@ $(function(){
 				imageCode = '<img src="'+url+'" alt="'+filename+'" title="'+filename+'"/>\r\n';
 				break;
 			case 'BBCode':
-				imageCode = '[img alt="'+filename+'" title="'+filename+'"]'+url+'[/img]\r\n';
+				imageCode = '[img]'+url+'[/img]\r\n';
 				break;
 			case 'Markdown':
 				imageCode = '!['+filename+']('+url+' "'+filename+'")\r\n';


### PR DESCRIPTION
Remove unsuported options `alt` and `title`. 

These options prevent Vanilla from properly rendering the image.

Fix #1
